### PR TITLE
Add ExecutionError#to_h

### DIFF
--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -42,7 +42,7 @@ impl ExecutionError {
     }
 
     pub fn to_h(&self) -> RHash {
-        let ruby_h = rhash_with_capacity(3);
+        let ruby_h = rhash_with_capacity(2);
         let _ = ruby_h.aset("message", self.message());
         _ = ruby_h.aset("path", self.path());
         ruby_h

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -1,10 +1,12 @@
+use crate::helpers::rhash_with_capacity;
+
 use super::root;
 use magnus::{
     function, method,
     rb_sys::AsRawValue,
     scan_args::scan_args,
     typed_data::{self, Obj},
-    Error, Module, Object, Value,
+    Error, Module, Object, Value, RHash,
 };
 use std::borrow::Cow;
 
@@ -39,6 +41,13 @@ impl ExecutionError {
         self.path.clone()
     }
 
+    pub fn to_h(&self) -> RHash {
+        let ruby_h = rhash_with_capacity(3);
+        let _ = ruby_h.aset("message", self.message());
+        _ = ruby_h.aset("path", self.path());
+        ruby_h
+    }
+
     fn inspect(rb_self: Obj<Self>) -> Result<String, Error> {
         let rs_self = rb_self.get();
 
@@ -62,6 +71,7 @@ pub fn init() -> Result<(), Error> {
         method!(<ExecutionError as typed_data::IsEql>::is_eql, 1),
     )?;
     class.define_method("inspect", method!(ExecutionError::inspect, 0))?;
+    class.define_method("to_h", method!(ExecutionError::to_h, 0))?;
 
     Ok(())
 }

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -41,10 +41,9 @@ impl ExecutionError {
         self.path.clone()
     }
 
-    pub fn to_h(&self) -> RHash {
+    fn to_h(&self) -> RHash {
         let ruby_h = rhash_with_capacity(2);
-        let _ = ruby_h.aset("message", self.message());
-        _ = ruby_h.aset("path", self.path());
+        ruby_h.bulk_insert(&[("path", self.path), ("message", self.message)])?;
         ruby_h
     }
 

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -41,10 +41,11 @@ impl ExecutionError {
         self.path.clone()
     }
 
-    fn to_h(&self) -> RHash {
+    fn to_h(&self) -> Result<RHash, Error> {
         let ruby_h = rhash_with_capacity(2);
-        ruby_h.bulk_insert(&[("path", self.path), ("message", self.message)])?;
-        ruby_h
+        ruby_h.aset("path", self.path())?;
+        ruby_h.aset("message", self.message())?;
+        Ok(ruby_h)
     }
 
     fn inspect(rb_self: Obj<Self>) -> Result<String, Error> {

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -6,7 +6,7 @@ use magnus::{
     rb_sys::AsRawValue,
     scan_args::scan_args,
     typed_data::{self, Obj},
-    Error, Module, Object, Value, RHash,
+    Error, Module, Object, RHash, Value,
 };
 use std::borrow::Cow;
 

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -11,7 +11,8 @@ module Bluejay
         "message" => "Something went wrong",
         "path" => ["root", "field", "0", "thing"],
       }
-      assert_equal expected_h, err.to_h
+
+      assert_equal(expected_h, err.to_h)
     end
   end
 end

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -1,0 +1,17 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Bluejay
+  class TestExecutionError < Minitest::Test
+    def test_it_responds_to_to_h
+      err = Bluejay::ExecutionError.new("Something went wrong", ["root", "field", "0", "thing"])
+      expected_h = {
+        "message" => "Something went wrong",
+        "path" => ["root", "field", "0", "thing"],
+      }
+      assert_equal expected_h, err.to_h
+    end
+  end
+end


### PR DESCRIPTION
This adds an output format to `Bluejay::ExecutionError`, via `#to_h` (this could be used in final responses). 

TODO: 

- ~~Add `locations`~~ I'll try this in a separate PR