### PR TITLE
Add locations to ExecutionError

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -16,8 +16,8 @@ itertools = "0.10.5"
 strum = { version = "0.24", features = ["derive"] }
 indexmap = "1.9.3"
 paste = "1.0"
-bluejay-parser = { git = "https://github.com/adampetro/bluejay", rev = "c6abb5390a0d0f16781fcb7cba50497e5d6b505d" }
-bluejay-core = { git = "https://github.com/adampetro/bluejay", rev = "c6abb5390a0d0f16781fcb7cba50497e5d6b505d" }
-bluejay-printer = { git = "https://github.com/adampetro/bluejay", rev = "c6abb5390a0d0f16781fcb7cba50497e5d6b505d" }
-bluejay-validator = { git = "https://github.com/adampetro/bluejay", rev = "c6abb5390a0d0f16781fcb7cba50497e5d6b505d" }
-bluejay-visibility = { git = "https://github.com/adampetro/bluejay", rev = "c6abb5390a0d0f16781fcb7cba50497e5d6b505d" }
+bluejay-parser = { git = "https://github.com/adampetro/bluejay", rev = "7d09f81aa42be3f2569a9e4d9fedf6577e8a299e" }
+bluejay-core = { git = "https://github.com/adampetro/bluejay", rev = "7d09f81aa42be3f2569a9e4d9fedf6577e8a299e" }
+bluejay-printer = { git = "https://github.com/adampetro/bluejay", rev = "7d09f81aa42be3f2569a9e4d9fedf6577e8a299e" }
+bluejay-validator = { git = "https://github.com/adampetro/bluejay", rev = "7d09f81aa42be3f2569a9e4d9fedf6577e8a299e" }
+bluejay-visibility = { git = "https://github.com/adampetro/bluejay", rev = "7d09f81aa42be3f2569a9e4d9fedf6577e8a299e" }

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -38,6 +38,7 @@ pub struct Engine<'a> {
     variables: &'a RHash,
     key_store: KeyStore<'a>,
     collect_fields_cache: CollectFieldsCache<'a>,
+    query: &'a str,
 }
 
 impl<'a> Engine<'a> {
@@ -92,6 +93,7 @@ impl<'a> Engine<'a> {
             variables: &variables,
             key_store: KeyStore::new(),
             collect_fields_cache: Default::default(),
+            query,
         };
 
         instance
@@ -575,6 +577,7 @@ impl<'a> Engine<'a> {
                     error: FieldError::ReturnedNullForNonNullType,
                     path,
                     fields: fields.to_vec(),
+                    query: self.query,
                 }],
             );
         } else if result.is_nil() {
@@ -591,6 +594,7 @@ impl<'a> Engine<'a> {
                             error,
                             path,
                             fields: fields.to_vec(),
+                            query: self.query,
                         }],
                     ),
                 },
@@ -602,6 +606,7 @@ impl<'a> Engine<'a> {
                             error,
                             path,
                             fields: fields.to_vec(),
+                            query: self.query,
                         }],
                     ),
                 },
@@ -613,6 +618,7 @@ impl<'a> Engine<'a> {
                             error,
                             path,
                             fields: fields.to_vec(),
+                            query: self.query,
                         }],
                     ),
                 },
@@ -654,6 +660,7 @@ impl<'a> Engine<'a> {
                             error: FieldError::ReturnedNonListForListType,
                             path,
                             fields: fields.to_vec(),
+                            query: self.query,
                         }],
                     )
                 }

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -574,6 +574,7 @@ impl<'a> Engine<'a> {
                 vec![ExecutionError::FieldError {
                     error: FieldError::ReturnedNullForNonNullType,
                     path,
+                    field: fields.first().unwrap(),
                 }],
             );
         } else if result.is_nil() {
@@ -584,15 +585,36 @@ impl<'a> Engine<'a> {
             OutputTypeReference::Base(inner, _) => match inner {
                 ScopedBaseOutputType::BuiltinScalar(bstd) => match bstd.coerce_result(result) {
                     Ok(value) => (value, vec![]),
-                    Err(error) => (*QNIL, vec![ExecutionError::FieldError { error, path }]),
+                    Err(error) => (
+                        *QNIL,
+                        vec![ExecutionError::FieldError {
+                            error,
+                            path,
+                            field: fields.first().unwrap(),
+                        }],
+                    ),
                 },
                 ScopedBaseOutputType::CustomScalar(cstd) => match cstd.coerce_result(result) {
                     Ok(value) => (value, vec![]),
-                    Err(error) => (*QNIL, vec![ExecutionError::FieldError { error, path }]),
+                    Err(error) => (
+                        *QNIL,
+                        vec![ExecutionError::FieldError {
+                            error,
+                            path,
+                            field: fields.first().unwrap(),
+                        }],
+                    ),
                 },
                 ScopedBaseOutputType::Enum(etd) => match etd.coerce_result(result) {
                     Ok(value) => (value, vec![]),
-                    Err(error) => (*QNIL, vec![ExecutionError::FieldError { error, path }]),
+                    Err(error) => (
+                        *QNIL,
+                        vec![ExecutionError::FieldError {
+                            error,
+                            path,
+                            field: fields.first().unwrap(),
+                        }],
+                    ),
                 },
                 ScopedBaseOutputType::Object(otd) => {
                     self.execute_selection_set(fields.into(), otd, result, path)
@@ -631,6 +653,7 @@ impl<'a> Engine<'a> {
                         vec![ExecutionError::FieldError {
                             error: FieldError::ReturnedNonListForListType,
                             path,
+                            field: fields.first().unwrap(),
                         }],
                     )
                 }

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -574,7 +574,7 @@ impl<'a> Engine<'a> {
                 vec![ExecutionError::FieldError {
                     error: FieldError::ReturnedNullForNonNullType,
                     path,
-                    field: fields.first().unwrap(),
+                    fields: fields.to_vec(),
                 }],
             );
         } else if result.is_nil() {
@@ -590,7 +590,7 @@ impl<'a> Engine<'a> {
                         vec![ExecutionError::FieldError {
                             error,
                             path,
-                            field: fields.first().unwrap(),
+                            fields: fields.to_vec(),
                         }],
                     ),
                 },
@@ -601,7 +601,7 @@ impl<'a> Engine<'a> {
                         vec![ExecutionError::FieldError {
                             error,
                             path,
-                            field: fields.first().unwrap(),
+                            fields: fields.to_vec(),
                         }],
                     ),
                 },
@@ -612,7 +612,7 @@ impl<'a> Engine<'a> {
                         vec![ExecutionError::FieldError {
                             error,
                             path,
-                            field: fields.first().unwrap(),
+                            fields: fields.to_vec(),
                         }],
                     ),
                 },
@@ -653,7 +653,7 @@ impl<'a> Engine<'a> {
                         vec![ExecutionError::FieldError {
                             error: FieldError::ReturnedNonListForListType,
                             path,
-                            field: fields.first().unwrap(),
+                            fields: fields.to_vec(),
                         }],
                     )
                 }

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -22,6 +22,7 @@ use bluejay_core::{
 };
 use bluejay_parser::ast::executable::{ExecutableDocument, Field, OperationDefinition, Selection};
 use bluejay_parser::ast::{Directive, VariableArguments, VariableValue};
+use bluejay_parser::error::SpanToLocation;
 use bluejay_validator::Path;
 use indexmap::IndexMap;
 use magnus::{Error, RArray, RHash, Value, QNIL};
@@ -200,7 +201,12 @@ impl<'a> Engine<'a> {
     }
 
     fn execution_result(value: Value, errors: Vec<ExecutionError>, query: &str) -> ExecutionResult {
-        ExecutionResult::new(value, errors)
+        let span_to_location = SpanToLocation::new(query);
+        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> = errors
+            .iter()
+            .map(|err| (err.clone(), span_to_location))
+            .collect();
+        ExecutionResult::new(value, errors_with_span_to_location)
     }
 
     fn execute_operation(

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -201,11 +201,16 @@ impl<'a> Engine<'a> {
     }
 
     fn execution_result(value: Value, errors: Vec<ExecutionError>, query: &str) -> ExecutionResult {
-        let span_to_location = SpanToLocation::new(query);
-        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> = errors
-            .iter()
-            .map(|err| (err.clone(), span_to_location))
-            .collect();
+        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> =
+            if errors.is_empty() {
+                vec![]
+            } else {
+                let span_to_location = SpanToLocation::new(query);
+                errors
+                    .iter()
+                    .map(|err| (err.clone(), span_to_location))
+                    .collect()
+            };
         ExecutionResult::new(value, errors_with_span_to_location)
     }
 

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -36,7 +36,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
                     // TODO This is starting byte and ending byte, not line and column
                     let span = field.span();
                     let range = span.byte_range();
-                    ErrorLocation { line: range.start, column: range.end }
+                    ErrorLocation::new(range.start, range.end)
                 };
 
                 let locations = Some(fields.iter().map(get_location).collect());

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -23,8 +23,8 @@ pub enum ExecutionError<'a> {
     },
 }
 
-impl<'a> From<(ExecutionError<'a>, SpanToLocation<'a>)> for RubyExecutionError {
-    fn from(val: (ExecutionError<'a>, SpanToLocation<'a>)) -> Self {
+impl<'a> From<(ExecutionError<'a>, &mut SpanToLocation<'a>)> for RubyExecutionError {
+    fn from(val: (ExecutionError<'a>, &mut SpanToLocation<'a>)) -> Self {
         let (execution_error, span_to_location) = val;
         match execution_error {
             ExecutionError::NoOperationWithName { name } => Self::new(format!("No operation definition named `{name}`"), None, None),

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -1,5 +1,5 @@
 use crate::execution::FieldError;
-use crate::ruby_api::{CoercionError, ExecutionError as RubyExecutionError};
+use crate::ruby_api::{CoercionError, ErrorLocation, ExecutionError as RubyExecutionError};
 use bluejay_parser::{Error as ParseError, HasSpan};
 use bluejay_validator::Path;
 
@@ -36,7 +36,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
                     // TODO This is starting byte and ending byte, not line and column
                     let span = field.span();
                     let range = span.byte_range();
-                    (range.start, range.end)
+                    ErrorLocation { line: range.start, column: range.end }
                 };
 
                 let locations = Some(fields.iter().map(get_location).collect());

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -1,29 +1,37 @@
 use crate::execution::FieldError;
 use crate::ruby_api::{CoercionError, ExecutionError as RubyExecutionError};
-use bluejay_parser::Error as ParseError;
+use bluejay_parser::{Error as ParseError, HasSpan};
 use bluejay_validator::Path;
 
 #[derive(Debug)]
 pub enum ExecutionError<'a> {
-    NoOperationWithName { name: &'a str },
+    NoOperationWithName {
+        name: &'a str,
+    },
     CannotUseAnonymousOperation,
-    RequiredVariableMissingValue { name: &'a str },
+    RequiredVariableMissingValue {
+        name: &'a str,
+    },
     ApplicationError(String),
     CoercionError(CoercionError),
     ParseError(ParseError),
-    FieldError { error: FieldError, path: Path<'a> },
+    FieldError {
+        error: FieldError,
+        path: Path<'a>,
+        field: &'a bluejay_parser::ast::executable::Field<'a>,
+    },
 }
 
 impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
     fn from(val: ExecutionError<'a>) -> Self {
         match val {
-            ExecutionError::NoOperationWithName { name } => Self::new(format!("No operation definition named `{name}`"), None),
-            ExecutionError::CannotUseAnonymousOperation => Self::new("Operation name is required when document does not contain exactly 1 operation definition", None),
-            ExecutionError::RequiredVariableMissingValue { name } => Self::new(format!("No value was provided for required variable `${name}`"), None),
-            ExecutionError::ApplicationError(error) => Self::new(format!("Internal error: {error}"), None),
+            ExecutionError::NoOperationWithName { name } => Self::new(format!("No operation definition named `{name}`"), None, None),
+            ExecutionError::CannotUseAnonymousOperation => Self::new("Operation name is required when document does not contain exactly 1 operation definition", None, None),
+            ExecutionError::RequiredVariableMissingValue { name } => Self::new(format!("No value was provided for required variable `${name}`"), None, None),
+            ExecutionError::ApplicationError(error) => Self::new(format!("Internal error: {error}"), None, None),
             ExecutionError::CoercionError(error) =>  error.into(),
-            ExecutionError::ParseError(error) => Self::new(error.message().to_owned(), None),
-            ExecutionError::FieldError { error, path } => Self::new(error.message().to_string(), Some(path.to_vec())),
+            ExecutionError::ParseError(error) => Self::new(error.message().to_owned(), None, None),
+            ExecutionError::FieldError { error, path, field } => Self::new(error.message().to_string(), Some(path.to_vec()), Some((field.span().byte_range().start, field.span().byte_range().end))),
         }
     }
 }

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -19,7 +19,6 @@ pub enum ExecutionError<'a> {
     FieldError {
         error: FieldError,
         path: Path<'a>,
-        query: &'a str,
         fields: Vec<&'a bluejay_parser::ast::executable::Field<'a>>,
     },
 }
@@ -33,7 +32,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
             ExecutionError::ApplicationError(error) => Self::new(format!("Internal error: {error}"), None, None),
             ExecutionError::CoercionError(error) =>  error.into(),
             ExecutionError::ParseError(error) => Self::new(error.message().to_owned(), None, None),
-            ExecutionError::FieldError { error, path, fields, query } => {
+            ExecutionError::FieldError { error, path, fields } => {
                 let get_location = |field: &&bluejay_parser::ast::executable::Field<'_>| {
                     let span = field.span();
                     let (line, column) = SpanToLocation::new(query).convert(span).unwrap();

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -23,9 +23,10 @@ pub enum ExecutionError<'a> {
     },
 }
 
-impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
-    fn from(val: ExecutionError<'a>) -> Self {
-        match val {
+impl<'a> From<(ExecutionError<'a>, SpanToLocation<'a>)> for RubyExecutionError {
+    fn from(val: (ExecutionError<'a>, SpanToLocation<'a>)) -> Self {
+        let (execution_error, span_to_location) = val;
+        match execution_error {
             ExecutionError::NoOperationWithName { name } => Self::new(format!("No operation definition named `{name}`"), None, None),
             ExecutionError::CannotUseAnonymousOperation => Self::new("Operation name is required when document does not contain exactly 1 operation definition", None, None),
             ExecutionError::RequiredVariableMissingValue { name } => Self::new(format!("No value was provided for required variable `${name}`"), None, None),
@@ -35,7 +36,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
             ExecutionError::FieldError { error, path, fields } => {
                 let get_location = |field: &&bluejay_parser::ast::executable::Field<'_>| {
                     let span = field.span();
-                    let (line, column) = SpanToLocation::new(query).convert(span).unwrap();
+                    let (line, column) = span_to_location.convert(span).unwrap();
                     ErrorLocation::new(line, column)
                 };
 

--- a/ext/src/ruby_api.rs
+++ b/ext/src/ruby_api.rs
@@ -49,6 +49,7 @@ pub use enum_type_definition::EnumTypeDefinition;
 pub use enum_value_definition::EnumValueDefinition;
 pub use enum_value_definitions::EnumValueDefinitions;
 pub use errors::{base_error, non_unique_definition_name_error};
+pub use execution_error::ErrorLocation;
 pub use execution_error::ExecutionError;
 pub use execution_result::ExecutionResult;
 pub use field_definition::{ExtraResolverArg, FieldDefinition};

--- a/ext/src/ruby_api/coercion_error.rs
+++ b/ext/src/ruby_api/coercion_error.rs
@@ -40,7 +40,7 @@ impl CoercionError {
 
 impl From<CoercionError> for ExecutionError {
     fn from(val: CoercionError) -> Self {
-        ExecutionError::new(val.message, None)
+        ExecutionError::new(val.message, None, None)
     }
 }
 

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -6,7 +6,7 @@ use magnus::{
     rb_sys::AsRawValue,
     scan_args::scan_args,
     typed_data::{self, Obj},
-    DataTypeFunctions, Error, Module, Object, RArray, RHash, TypedData, Value,
+    DataTypeFunctions, Error, Integer, Module, Object, RArray, RHash, TypedData, Value,
 };
 use std::borrow::Cow;
 
@@ -22,9 +22,9 @@ impl ErrorLocation {
         Self { line, column }
     }
 
-    fn rb_new(hash: RHash) -> Result<Self, Error> {
-        let line = hash.get("line").unwrap().try_convert::<usize>().unwrap();
-        let column = hash.get("column").unwrap().try_convert::<usize>().unwrap();
+    fn rb_new(line_v: Integer, col_v: Integer) -> Result<Self, Error> {
+        let line = line_v.try_convert::<usize>().unwrap();
+        let column = col_v.try_convert::<usize>().unwrap();
         Ok(Self::new(line, column))
     }
 
@@ -132,7 +132,11 @@ pub fn init() -> Result<(), Error> {
     class.define_method("to_h", method!(ExecutionError::to_h, 0))?;
 
     let loc_class = class.define_class("ErrorLocation", Default::default())?;
-    loc_class.define_singleton_method("new", function!(ErrorLocation::rb_new, 1))?;
+    loc_class.define_singleton_method("new", function!(ErrorLocation::rb_new, 2))?;
+    loc_class.define_method(
+        "==",
+        method!(<ErrorLocation as typed_data::IsEql>::is_eql, 1),
+    )?;
 
     Ok(())
 }

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -34,6 +34,17 @@ impl ErrorLocation {
         ruby_h.aset("column", self.column)?;
         Ok(ruby_h)
     }
+
+    fn inspect(rb_self: Obj<Self>) -> Result<String, Error> {
+        let rs_self = rb_self.get();
+
+        Ok(format!(
+            "#<Bluejay::ExecutionError::ErrorLocation:0x{:016x} @line={:?} @column={:?}>",
+            rb_self.as_raw(),
+            rs_self.line,
+            rs_self.column,
+        ))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TypedData)]
@@ -133,6 +144,7 @@ pub fn init() -> Result<(), Error> {
 
     let loc_class = class.define_class("ErrorLocation", Default::default())?;
     loc_class.define_singleton_method("new", function!(ErrorLocation::rb_new, 2))?;
+    loc_class.define_method("inspect", method!(ErrorLocation::inspect, 0))?;
     loc_class.define_method(
         "==",
         method!(<ErrorLocation as typed_data::IsEql>::is_eql, 1),

--- a/ext/src/ruby_api/execution_error.rs
+++ b/ext/src/ruby_api/execution_error.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[magnus::wrap(class = "Bluejay::ExecutionError::ErrorLocation")]
-struct ErrorLocation {
+pub struct ErrorLocation {
     line: usize,
     column: usize,
 }

--- a/ext/src/ruby_api/execution_result.rs
+++ b/ext/src/ruby_api/execution_result.rs
@@ -13,7 +13,7 @@ pub struct ExecutionResult {
 }
 
 impl ExecutionResult {
-    pub fn new(value: Value, errors: impl IntoIterator<Item = impl Into<ExecutionError>>) -> Self {
+    pub fn new(value: Value, errors: impl Iterator<Item = ExecutionError>) -> Self {
         let errors = TypedFrozenRArray::from_iter(errors.into_iter().map(Into::into));
         Self { value, errors }
     }

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -14,11 +14,11 @@ module Bluejay
 
       assert_equal(expected_h, err.to_h)
 
-      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [10, 12])
+      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [[10, 12]])
       expected_h2 = {
         "message" => "Something else went wrong",
         "path" => ["root"],
-        "locations" => [10, 12],
+        "locations" => [[10, 12]],
       }
 
       assert_equal(expected_h2, err2.to_h)

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -23,5 +23,9 @@ module Bluejay
 
       assert_equal(expected_h2, err2.to_h)
     end
+
+    def test_it_can_make_error_locations
+      assert(Bluejay::ExecutionError::ErrorLocation.new({ "line" => 5, "column" => 10 }))
+    end
   end
 end

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -17,7 +17,7 @@ module Bluejay
       err2 = Bluejay::ExecutionError.new(
         "Something else went wrong",
         ["root"],
-        [Bluejay::ExecutionError::ErrorLocation.new(10, 12)],
+        [Bluejay::ExecutionError::ErrorLocation.new(line: 10, column: 12)],
       )
       expected_h2 = {
         "message" => "Something else went wrong",
@@ -29,7 +29,7 @@ module Bluejay
     end
 
     def test_it_can_make_error_locations
-      assert(Bluejay::ExecutionError::ErrorLocation.new(5, 10))
+      assert(Bluejay::ExecutionError::ErrorLocation.new(line: 5, column: 10))
     end
   end
 end

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -14,7 +14,11 @@ module Bluejay
 
       assert_equal(expected_h, err.to_h)
 
-      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [{ "line" => 10, "column" => 12 }])
+      err2 = Bluejay::ExecutionError.new(
+        "Something else went wrong",
+        ["root"],
+        [Bluejay::ExecutionError::ErrorLocation.new(10, 12)],
+      )
       expected_h2 = {
         "message" => "Something else went wrong",
         "path" => ["root"],
@@ -25,7 +29,7 @@ module Bluejay
     end
 
     def test_it_can_make_error_locations
-      assert(Bluejay::ExecutionError::ErrorLocation.new({ "line" => 5, "column" => 10 }))
+      assert(Bluejay::ExecutionError::ErrorLocation.new(5, 10))
     end
   end
 end

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -14,11 +14,11 @@ module Bluejay
 
       assert_equal(expected_h, err.to_h)
 
-      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [[10, 12]])
+      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [{ "line" => 10, "column" => 12 }])
       expected_h2 = {
         "message" => "Something else went wrong",
         "path" => ["root"],
-        "locations" => [[10, 12]],
+        "locations" => [{ "line" => 10, "column" => 12 }],
       }
 
       assert_equal(expected_h2, err2.to_h)

--- a/test/bluejay/test_execution_error.rb
+++ b/test/bluejay/test_execution_error.rb
@@ -13,6 +13,15 @@ module Bluejay
       }
 
       assert_equal(expected_h, err.to_h)
+
+      err2 = Bluejay::ExecutionError.new("Something else went wrong", ["root"], [10, 12])
+      expected_h2 = {
+        "message" => "Something else went wrong",
+        "path" => ["root"],
+        "locations" => [10, 12],
+      }
+
+      assert_equal(expected_h2, err2.to_h)
     end
   end
 end

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -290,7 +290,10 @@ module Bluejay
     end
 
     def test_execute_custom_scalar_coerce_result_error
-      query = "{ today today }"
+      query = "{
+        today
+        today
+      }"
       root = Domain::SchemaRoot.new(query: Domain::QueryRoot.new(today: Date.today.next_day))
 
       result = MySchema.execute(
@@ -304,7 +307,7 @@ module Bluejay
         ExecutionError.new(
           "Did not return today",
           ["today"],
-          [Bluejay::ExecutionError::ErrorLocation.new(2, 7), Bluejay::ExecutionError::ErrorLocation.new(8, 13)],
+          [Bluejay::ExecutionError::ErrorLocation.new(2, 9), Bluejay::ExecutionError::ErrorLocation.new(3, 9)],
         ),
         result.errors.first,
       )

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -290,7 +290,7 @@ module Bluejay
     end
 
     def test_execute_custom_scalar_coerce_result_error
-      query = "{ today }"
+      query = "{ today today }"
       root = Domain::SchemaRoot.new(query: Domain::QueryRoot.new(today: Date.today.next_day))
 
       result = MySchema.execute(
@@ -301,7 +301,7 @@ module Bluejay
 
       assert_equal(1, result.errors.length)
       assert_equal(
-        ExecutionError.new("Did not return today", ["today"], [2, 7]),
+        ExecutionError.new("Did not return today", ["today"], [[2, 7], [8, 13]]),
         result.errors.first,
       )
     end

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -307,7 +307,10 @@ module Bluejay
         ExecutionError.new(
           "Did not return today",
           ["today"],
-          [Bluejay::ExecutionError::ErrorLocation.new(2, 9), Bluejay::ExecutionError::ErrorLocation.new(3, 9)],
+          [
+            Bluejay::ExecutionError::ErrorLocation.new(line: 2, column: 9),
+            Bluejay::ExecutionError::ErrorLocation.new(line: 3, column: 9),
+          ],
         ),
         result.errors.first,
       )

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -301,7 +301,7 @@ module Bluejay
 
       assert_equal(1, result.errors.length)
       assert_equal(
-        ExecutionError.new("Did not return today", ["today"]),
+        ExecutionError.new("Did not return today", ["today"], [2, 7]),
         result.errors.first,
       )
     end

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -301,7 +301,11 @@ module Bluejay
 
       assert_equal(1, result.errors.length)
       assert_equal(
-        ExecutionError.new("Did not return today", ["today"], [[2, 7], [8, 13]]),
+        ExecutionError.new(
+          "Did not return today",
+          ["today"],
+          [{ "line" => 2, "column" => 7 }, { "line" => 8, "column" => 13 }],
+        ),
         result.errors.first,
       )
     end

--- a/test/bluejay/test_schema.rb
+++ b/test/bluejay/test_schema.rb
@@ -304,7 +304,7 @@ module Bluejay
         ExecutionError.new(
           "Did not return today",
           ["today"],
-          [{ "line" => 2, "column" => 7 }, { "line" => 8, "column" => 13 }],
+          [Bluejay::ExecutionError::ErrorLocation.new(2, 7), Bluejay::ExecutionError::ErrorLocation.new(8, 13)],
         ),
         result.errors.first,
       )


### PR DESCRIPTION
This adds `[ { "line": line1, "column": col1 }, { "line": line2, "column:" col2 }, ... ]` locations to ExecutionError. They should be populated during initialization and included in the `#to_h` output of the error. 

TODO: 

- [x] Make `locations` plural (currently it only supports a single location); stop using `fields.first()` -- use them all instead
- [x] Use hashes instead of arrays for each location
- [x] Clean up `(usize, usize)` -- give that type a name? 
- [ ] Try populating and testing locations in other cases? 
- [x] Don't call `.byte_range()` twice 
- [x] Currently it's actually returning the start and end of the byte range -- how to turn this into line and column?